### PR TITLE
fix crud datetime_created

### DIFF
--- a/src/coastapp/classification.py
+++ b/src/coastapp/classification.py
@@ -184,8 +184,13 @@ class ClassificationManager(CRUDManager):
         # Determine time values
         current_datetime = datetime.datetime.now(datetime.UTC).isoformat()
 
-        # Set time_created if it doesn't exist, otherwise update time_updated
-        datetime_created = self.record.get("datetime_created", current_datetime)
+        # NOTE: you cannot use self.record.get("datetime_created", current_datetime)
+        # because then you will find the default value, which is an empty string. See
+        # default schema. So, if datetime_created is an empty string, set it to current_datetime
+        datetime_created = self.record.get("datetime_created")
+        if not datetime_created:
+            datetime_created = current_datetime
+
         datetime_updated = current_datetime
 
         universal_unique_id = uuid.uuid4().hex[:12]

--- a/src/coastapp/crud.py
+++ b/src/coastapp/crud.py
@@ -49,7 +49,7 @@ class CRUDManager(ABC):
         """Constructs the signed HTTPS URL with the SAS token."""
         return f"{self.base_url}/{record_name}?{self.storage_options['sas_token']}"
 
-    def save_record(self, record: dict):
+    def create_record(self, record: dict):
         """Saves a record to the Azure storage backend using the az:// protocol."""
         record_name = self.generate_filename(record)
         full_path = self._get_storage_path(record_name)
@@ -59,9 +59,11 @@ class CRUDManager(ABC):
             f.write(record_json)
         logger.info(f"Saved record: {full_path}")
 
-    def create_record(self, record: dict):
-        """Creates a new record and saves it."""
-        self.save_record(record)
+    # def create_record(self, record: dict):
+    #     """Creates a new record and saves it."""
+    #     datetime_created = datetime.datetime.now(datetime.UTC).isoformat()
+    #     record["datetime_created"] = datetime_created
+    #     self.save_record(record)
 
     def read_record(self, record_name: str) -> dict:
         """Reads a record from the Azure storage backend using HTTPS."""
@@ -75,7 +77,7 @@ class CRUDManager(ABC):
         """Updates an existing record in the Azure storage backend using the az:// protocol."""
         record = self.read_record(record_name)
         record.update(updated_data)
-        self.save_record(record)
+        self.create_record(record)
 
     def delete_record(self, record_name: str):
         """Deletes a record from the Azure storage backend using the az:// protocol."""


### PR DESCRIPTION
- rm save_record and only use create_record 
- infer datetime_created by evaluating if string is empty and not by getting because the default is an empty "" which is found by d.get()